### PR TITLE
Fix MxPalette structure and match ctor/dtor

### DIFF
--- a/LEGO1/mxpalette.cpp
+++ b/LEGO1/mxpalette.cpp
@@ -4,16 +4,17 @@
 MxPalette::MxPalette()
 {
   this->m_overrideSkyColor = FALSE;
-  this->m_attached = NULL;
+  this->m_palette = NULL;
   GetDefaultPalette(this->m_entries);
   this->m_skyColor = this->m_entries[141];
-  // FIXME: Incomplete
 }
 
 // OFFSET: LEGO1 100bef90
 MxPalette::~MxPalette()
 {
-  delete m_attached;  // yes this matches more
+  if (m_palette) {
+    m_palette->Release();
+  }
 }
 
 // OFFSET: LEGO1 100bf0b0
@@ -55,5 +56,5 @@ void MxPalette::GetDefaultPalette(LPPALETTEENTRY p_entries)
 // OFFSET: LEGO1 0x100bf330
 void MxPalette::Detach()
 {
-  this->m_attached = NULL;
+  this->m_palette = NULL;
 }

--- a/LEGO1/mxpalette.h
+++ b/LEGO1/mxpalette.h
@@ -15,13 +15,13 @@ public:
   __declspec(dllexport) void Detach();
 
   MxPalette();
-  ~MxPalette();
+  virtual ~MxPalette();
+
   MxPalette* Clone();
   void GetDefaultPalette(LPPALETTEENTRY p_entries);
   MxResult GetEntries(LPPALETTEENTRY p_entries);
 
 private:
-  MxCore *m_attached;
   LPDIRECTDRAWPALETTE m_palette;
   PALETTEENTRY m_entries[256];
   MxBool m_overrideSkyColor;


### PR DESCRIPTION
This is in reference to your comment in https://github.com/isledecomp/isle/pull/56. You have to be careful when relying on the "decompiler" of Ghidra etc., they are just "best effort" approximations and many things you see in there will not necessarily be correct. `m_attached` does not exist; it is the pointer to the `DIRECTDRAWPALETTE` resource that is being released.

I've applied the fixes in this PR. This should help you to match/implement other things in the class.