### PR TITLE
A few more MxDirect3D functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(lego1 SHARED
   LEGO1/mxcontrolpresenter.cpp
   LEGO1/mxcore.cpp
   LEGO1/mxcriticalsection.cpp
+  LEGO1/mxdirect3d.cpp
   LEGO1/mxdirectdraw.cpp
   LEGO1/mxdirect3d.cpp
   LEGO1/mxdiskstreamcontroller.cpp
@@ -206,7 +207,7 @@ if (ISLE_USE_DX5)
 endif()
 
 # Link libraries
-target_link_libraries(lego1 PRIVATE ddraw dsound winmm)
+target_link_libraries(lego1 PRIVATE ddraw dsound dxguid winmm)
 
 # Make sure filenames are ALL CAPS
 set_property(TARGET lego1 PROPERTY OUTPUT_NAME LEGO1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,6 @@ add_library(lego1 SHARED
   LEGO1/mxcontrolpresenter.cpp
   LEGO1/mxcore.cpp
   LEGO1/mxcriticalsection.cpp
-  LEGO1/mxdirect3d.cpp
   LEGO1/mxdirectdraw.cpp
   LEGO1/mxdirect3d.cpp
   LEGO1/mxdiskstreamcontroller.cpp

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -1,6 +1,9 @@
 #include "mxdirect3d.h"
+#include <stdio.h> // for vsprintf
 
 DECOMP_SIZE_ASSERT(MxDirect3D, 0x894);
+DECOMP_SIZE_ASSERT(MxDeviceModeFinder, 0xe4);
+DECOMP_SIZE_ASSERT(MxDeviceEnumerate, 0x198);
 
 // OFFSET: LEGO1 0x1009b0a0
 MxDirect3D::MxDirect3D()
@@ -9,6 +12,65 @@ MxDirect3D::MxDirect3D()
   this->m_pDirect3dDevice = NULL;
   this->m_unk88c = NULL;
   this->m_pDeviceModeFinder = NULL;
+}
+
+// OFFSET: LEGO1 0x1009b140
+MxDirect3D::~MxDirect3D()
+{
+  Destroy();
+}
+
+// OFFSET: LEGO1 0x1009b1a0
+BOOL MxDirect3D::Create(
+  HWND hWnd,
+  BOOL fullscreen_1,
+  BOOL surface_fullscreen,
+  BOOL onlySystemMemory,
+  int width,
+  int height,
+  int bpp,
+  const PALETTEENTRY* pPaletteEntries,
+  int paletteEntryCount)
+{
+  BOOL success = FALSE;
+
+  BOOL ret = MxDirectDraw::Create(hWnd, fullscreen_1, surface_fullscreen,
+                                  onlySystemMemory, width, height, bpp,
+                                  pPaletteEntries, paletteEntryCount);
+  
+  if (ret && CreateIDirect3D() && D3DSetMode())
+    success = TRUE;
+
+  if (!success)
+    FUN_1009D920();
+
+  return success;
+}
+
+// OFFSET: LEGO1 0x1009b210
+void MxDirect3D::Destroy()
+{
+  if (this->m_pDirect3dDevice) {
+    this->m_pDirect3dDevice->Release();
+    this->m_pDirect3dDevice = NULL;
+  }
+
+  if (this->m_pDirect3d) {
+    this->m_pDirect3d->Release();
+    this->m_pDirect3d = NULL;
+  }
+
+  if (this->m_pDeviceModeFinder) {
+    delete m_pDeviceModeFinder;
+    this->m_pDeviceModeFinder = NULL;
+  }
+
+  // This should get deleted by MxDirectDraw::Destroy
+  if (m_pCurrentDeviceModesList) {
+    m_pCurrentDeviceModesList = NULL;
+  }
+
+  MxDirectDraw::Destroy();
 }
 
 // OFFSET: LEGO1 0x1009b290
@@ -23,4 +85,94 @@ void MxDirect3D::Clear()
     this->m_pDirect3d = NULL;
   }
   MxDirectDraw::DestroyButNotDirectDraw();
+}
+
+// OFFSET: LEGO1 0x1009b2d0
+BOOL MxDirect3D::CreateIDirect3D()
+{
+  MxResult ret = IDirect3D_QueryInterface(m_pDirectDraw,
+                                          IID_IDirect3D2,
+                                          (LPVOID*)&m_pDirect3d);
+
+  if (ret) {
+    Error("Creation of IDirect3D failed", ret);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009b310 STUB
+BOOL MxDirect3D::D3DSetMode()
+{
+  // TODO
+  //if (m_pDeviceModeFinder)
+  Error("This device cannot support the current display mode", 0);
+  OutputDebugString("MxDirect3D::D3DSetMode() front lock failed\n");
+  OutputDebugString("MxDirect3D::D3DSetMode() back lock failed\n");
+  return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009b8b0
+MxDeviceModeFinder::MxDeviceModeFinder()
+{
+  memset(this, 0, sizeof(*this));
+}
+
+// OFFSET: LEGO1 0x1009b8d0
+MxDeviceModeFinder::~MxDeviceModeFinder()
+{
+  if (m_deviceInfo) {
+    delete m_deviceInfo;
+    m_deviceInfo = NULL;
+  }
+}
+
+// OFFSET: LEGO1 0x1009c070 STUB
+BOOL MxDirect3D::FUN_1009c070()
+{
+  //DirectDrawCreate()
+  //BuildErrorString("GetCaps failed: %s\n", xxx);
+  //IDirect3D2_EnumDevices
+  return TRUE;
+}
+
+// OFFSET: LEGO1 0x1009c4c0
+void MxDirect3D::BuildErrorString(const char *p_format, char *p_msg)
+{
+  char buf[512];
+  vsprintf(buf, p_format, p_msg);
+  OutputDebugString(buf);
+}
+
+// OFFSET: LEGO1 0x1009c6c0
+MxResult MxDeviceEnumerate::_DoEnumerate()
+{
+  if (m_unk010_flag)
+    return FAILURE;
+
+  HRESULT ret = DirectDrawEnumerate(EnumerateCallback, this);
+  if (ret) {
+    MxDirect3D::BuildErrorString("DirectDrawEnumerate returned error %s\n",
+                                 MxDirect3D::D3DErrorToString(ret));
+    return FAILURE;
+  }
+
+  m_unk010_flag = TRUE;
+  return SUCCESS;
+}
+
+// OFFSET: LEGO1 0x1009c710 STUB
+BOOL FAR PASCAL EnumerateCallback(GUID FAR *, LPSTR, LPSTR, LPVOID)
+{
+  return FALSE;
+}
+
+// OFFSET: LEGO1 0x1009c730 STUB
+char *MxDirect3D::D3DErrorToString(HRESULT p_error)
+{
+  // TODO: This is a list of error messages, similar to the function in
+  // MxDirectDraw, except that this one now contains the Direct3D errors.
+  // Probably just copied from a sample file in the dx5 sdk.
+  return "";
 }

--- a/LEGO1/mxdirect3d.cpp
+++ b/LEGO1/mxdirect3d.cpp
@@ -67,6 +67,7 @@ void MxDirect3D::Destroy()
 
   // This should get deleted by MxDirectDraw::Destroy
   if (m_pCurrentDeviceModesList) {
+    // delete m_pCurrentDeviceModesList; // missing?
     m_pCurrentDeviceModesList = NULL;
   }
 
@@ -129,10 +130,15 @@ MxDeviceModeFinder::~MxDeviceModeFinder()
 }
 
 // OFFSET: LEGO1 0x1009c070 STUB
-BOOL MxDirect3D::FUN_1009c070()
+BOOL MxDeviceEnumerate::FUN_1009c070()
 {
-  //DirectDrawCreate()
-  //BuildErrorString("GetCaps failed: %s\n", xxx);
+  // TODO
+  // HRESULT ret = DirectDrawCreate();
+  HRESULT ret = 0;
+  if (ret) {
+    MxDirect3D::BuildErrorString("GetCaps failed: %s\n",
+                                 EnumerateErrorToString(ret));
+  }
   //IDirect3D2_EnumDevices
   return TRUE;
 }
@@ -148,13 +154,14 @@ void MxDirect3D::BuildErrorString(const char *p_format, char *p_msg)
 // OFFSET: LEGO1 0x1009c6c0
 MxResult MxDeviceEnumerate::_DoEnumerate()
 {
+  // TODO: what does ECX refer to in this context?
   if (m_unk010_flag)
     return FAILURE;
 
   HRESULT ret = DirectDrawEnumerate(EnumerateCallback, this);
   if (ret) {
     MxDirect3D::BuildErrorString("DirectDrawEnumerate returned error %s\n",
-                                 MxDirect3D::D3DErrorToString(ret));
+                                 EnumerateErrorToString(ret));
     return FAILURE;
   }
 
@@ -165,11 +172,12 @@ MxResult MxDeviceEnumerate::_DoEnumerate()
 // OFFSET: LEGO1 0x1009c710 STUB
 BOOL FAR PASCAL EnumerateCallback(GUID FAR *, LPSTR, LPSTR, LPVOID)
 {
+  // TODO
   return FALSE;
 }
 
 // OFFSET: LEGO1 0x1009c730 STUB
-char *MxDirect3D::D3DErrorToString(HRESULT p_error)
+char *MxDeviceEnumerate::EnumerateErrorToString(HRESULT p_error)
 {
   // TODO: This is a list of error messages, similar to the function in
   // MxDirectDraw, except that this one now contains the Direct3D errors.

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -2,12 +2,39 @@
 #define MXDIRECT3D_H
 
 #include "mxdirectdraw.h"
+#include "mxtypes.h"
 #include "decomp.h"
 
 #include <d3d.h>
 
-class MxDeviceModeFinder;
+// SIZE 0xe4
+class MxDeviceModeFinder
+{
+public:
+  MxDeviceModeFinder();
+  ~MxDeviceModeFinder();
 
+  undefined4 m_unknown[56];
+  MxDirectDraw::DeviceModesInfo *m_deviceInfo; // +0xe0
+};
+
+// SIZE 0x198
+class MxDeviceEnumerate
+{
+public:
+  MxDeviceEnumerate();
+  MxResult _DoEnumerate();
+
+  undefined4 m_unk000;
+  undefined4 m_unk004;
+  undefined4 m_unk008;
+  undefined4 m_unk00c;
+  BOOL m_unk010_flag; // +0x20
+
+  undefined4 m_unknown[97];
+};
+
+// VTABLE 0x100db800
 // SIZE 0x894
 class MxDirect3D : public MxDirectDraw
 {
@@ -17,12 +44,35 @@ public:
   void Clear();
   inline MxDeviceModeFinder *GetDeviceModeFinder() { return this->m_pDeviceModeFinder; };
 
+  virtual ~MxDirect3D();
+  virtual BOOL Create(
+    HWND hWnd,
+    BOOL fullscreen_1,
+    BOOL surface_fullscreen,
+    BOOL onlySystemMemory,
+    int width,
+    int height,
+    int bpp,
+    const PALETTEENTRY* pPaletteEntries,
+    int paletteEntryCount);
+  virtual void Destroy();
+
+  BOOL CreateIDirect3D();
+  BOOL D3DSetMode();
+  BOOL FUN_1009c070();
+  MxResult _DoEnumerate();
+
+  static void BuildErrorString(const char *, char *);
+  static char *D3DErrorToString(HRESULT p_error);
+
 private:
-  MxDeviceModeFinder *m_pDeviceModeFinder;
-  IDirect3D *m_pDirect3d;
+  MxDeviceModeFinder *m_pDeviceModeFinder; // +0x880
+  IDirect3D *m_pDirect3d; // +0x884
   IDirect3DDevice *m_pDirect3dDevice;
   undefined4 m_unk88c;
   undefined4 m_unk890;
 };
+
+BOOL FAR PASCAL EnumerateCallback(GUID FAR *, LPSTR, LPSTR, LPVOID);
 
 #endif // MXDIRECT3D_H

--- a/LEGO1/mxdirect3d.h
+++ b/LEGO1/mxdirect3d.h
@@ -18,18 +18,21 @@ public:
   MxDirectDraw::DeviceModesInfo *m_deviceInfo; // +0xe0
 };
 
+// VTABLE 0x100db814 (or 0x100d9cc8?)
 // SIZE 0x198
 class MxDeviceEnumerate
 {
 public:
   MxDeviceEnumerate();
-  MxResult _DoEnumerate();
+  virtual MxResult _DoEnumerate();
+  BOOL FUN_1009c070();
 
-  undefined4 m_unk000;
+  static char *EnumerateErrorToString(HRESULT p_error);
+
   undefined4 m_unk004;
   undefined4 m_unk008;
   undefined4 m_unk00c;
-  BOOL m_unk010_flag; // +0x20
+  MxBool m_unk010_flag; // +0x10
 
   undefined4 m_unknown[97];
 };
@@ -59,11 +62,8 @@ public:
 
   BOOL CreateIDirect3D();
   BOOL D3DSetMode();
-  BOOL FUN_1009c070();
-  MxResult _DoEnumerate();
 
   static void BuildErrorString(const char *, char *);
-  static char *D3DErrorToString(HRESULT p_error);
 
 private:
   MxDeviceModeFinder *m_pDeviceModeFinder; // +0x880

--- a/LEGO1/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectdraw.cpp
@@ -1,8 +1,8 @@
-
 #include "mxdirectdraw.h"
 #include "decomp.h"
 
 DECOMP_SIZE_ASSERT(MxDirectDraw, 0x880);
+DECOMP_SIZE_ASSERT(MxDirectDraw::DeviceModesInfo, 0x17c);
 
 #ifndef DDSCAPS_3DDEVICE
 #define DDSCAPS_3DDEVICE 0x00002000l
@@ -28,6 +28,12 @@ void EnableResizing(HWND hwnd, BOOL flag)
   {
     SetWindowLong(hwnd, GWL_STYLE, dwStyle);
   }
+}
+
+// OFFSET: LEGO1 0x1009efb0
+MxDirectDraw::DeviceModesInfo::DeviceModesInfo()
+{
+  memset(this, 0, sizeof(*this));
 }
 
 // OFFSET: LEGO1 0x1009EFD0

--- a/LEGO1/mxdirectdraw.h
+++ b/LEGO1/mxdirectdraw.h
@@ -1,4 +1,3 @@
-
 #ifndef MXDIRECTDRAW_H
 #define MXDIRECTDRAW_H
 
@@ -7,6 +6,7 @@
 
 extern BOOL g_is_PALETTEINDEXED8;
 
+// VTABLE 0x100db818
 // SIZE 0x880
 class MxDirectDraw
 {
@@ -37,11 +37,12 @@ public:
     DDCAPS m_ddcaps;
     void* a_178;
 
+    DeviceModesInfo();
     ~DeviceModesInfo();
   };
 
 
-private:
+protected:
   BOOL m_bOnlySoftRender;
   BOOL m_bFlipSurfaces;
   IDirectDraw* m_pDirectDraw;
@@ -94,7 +95,7 @@ public:
   virtual void DestroyButNotDirectDraw();
   virtual const char* ErrorToString(HRESULT error);
 
-private:
+protected:
   BOOL CacheOriginalPaletteEntries();
   HRESULT CreateDDSurface(
     LPDDSURFACEDESC a2,


### PR DESCRIPTION
Merging in what I had from the pastebin.

MxDirect3D extends MxDirectDraw and needs to access the members, so I changed the scoping in the superclass to *protected* instead of *private*. I added a size assert and constructor for one of the component structs also.

We are now linking dxguid thanks to the hint from @madebr.

When I was hacking away at this originally, I added the functions around the "enumerate" callback and object to demonstrate how the error text was being built up. Those are still here, but I'm not confident that this is used _only_ for enumerating the devices. Maybe it's a generic "context" object?

The device mode finder struct is a similar case to the enumerate struct where I'm not 100% certain on what it is, but in this case there was a connection based on the size of the DeviceModesInfo member being allocated based on the size.